### PR TITLE
Use extended regex syntax instead of pearl syntax.

### DIFF
--- a/rdf
+++ b/rdf
@@ -158,7 +158,7 @@ _getFeatures()
     features=""
     for namespace in `cat $prefixlocal $prefixcache| grep "|" | cut -d "|" -f 2`
     do
-        namespaceCount=`grep -P "$namespace[a-zA-Z]+\>" $file | wc -l`
+        namespaceCount=`grep -E "$namespace[a-zA-Z]+\>" $file | wc -l`
         if [[ "$namespaceCount" -ge 1 ]]; then
             prefix=`_getPrefixForNamespace $namespace`
             #echo "Found $namespace -> $prefix"


### PR DESCRIPTION
Improves compatibility with BSD grep.
